### PR TITLE
Update docker image to v1.0.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.2
+FROM alpine:3.4
 MAINTAINER Jan Broer <janeczku@yahoo.com>
 
-ADD https://github.com/janeczku/go-dnsmasq/releases/download/1.0.0/go-dnsmasq_linux-amd64 /go-dnsmasq
+ADD https://github.com/janeczku/go-dnsmasq/releases/download/1.0.6/go-dnsmasq-min_linux-amd64 /go-dnsmasq
 RUN chmod +x /go-dnsmasq
 
 ENV DNSMASQ_LISTEN=0.0.0.0


### PR DESCRIPTION
In order to provide the latest version to users of the docker image update the image to download the `1.0.6` version instead of `1.0.0`. Also update to `alpine:3.4`.

**current state**

``` bash
# docker run --rm -ti janeczku/go-dnsmasq:release-1.0.6 --help
Unable to find image 'janeczku/go-dnsmasq:release-1.0.6' locally
release-1.0.6: Pulling from janeczku/go-dnsmasq
a01c74355a5f: Pull complete
459d93e10de1: Pull complete
c5e2efa27129: Pull complete
Digest: sha256:90739fce3aba549287cde96637e9edc2333b31905a7d2d0592c87d3157ba31a7
Status: Downloaded newer image for janeczku/go-dnsmasq:release-1.0.6
NAME:
   go-dnsmasq - Lightweight caching DNS server/forwarder

USAGE:
   go-dnsmasq [global options] command [command options] [arguments...]

VERSION:
   1.0.0
[...]
```
