### PR TITLE
Adds new feature for caching dns scenario when upstream goes down

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -36,7 +36,7 @@ func TestInsertMessage(t *testing.T) {
 	for _, tc := range testcases {
 		c.InsertMessage(Key(tc.m.Question[0], tc.dnssec, tc.tcp), tc.m)
 
-		m1 := c.Hit(tc.m.Question[0], tc.dnssec, tc.tcp, tc.m.Id)
+		m1, expired, key := c.Hit(tc.m.Question[0], tc.dnssec, tc.tcp, tc.m.Id)
 		if m1.Question[0].Qtype != tc.m.Question[0].Qtype {
 			t.Fatalf("bad Qtype, expected %d, got %d:", tc.m.Question[0].Qtype, m1.Question[0].Qtype)
 		}
@@ -44,15 +44,15 @@ func TestInsertMessage(t *testing.T) {
 			t.Fatalf("bad Qtype, expected %s, got %s:", tc.m.Question[0].Name, m1.Question[0].Name)
 		}
 
-		m1 = c.Hit(tc.m.Question[0], !tc.dnssec, tc.tcp, tc.m.Id)
+		m1, expired, key = c.Hit(tc.m.Question[0], !tc.dnssec, tc.tcp, tc.m.Id)
 		if m1 != nil {
 			t.Fatalf("bad cache hit, expected <nil>, got %s:", m1)
 		}
-		m1 = c.Hit(tc.m.Question[0], !tc.dnssec, !tc.tcp, tc.m.Id)
+		m1, expired, key = c.Hit(tc.m.Question[0], !tc.dnssec, !tc.tcp, tc.m.Id)
 		if m1 != nil {
 			t.Fatalf("bad cache hit, expected <nil>, got %s:", m1)
 		}
-		m1 = c.Hit(tc.m.Question[0], tc.dnssec, !tc.tcp, tc.m.Id)
+		m1, expired, key = c.Hit(tc.m.Question[0], tc.dnssec, !tc.tcp, tc.m.Id)
 		if m1 != nil {
 			t.Fatalf("bad cache hit, expected <nil>, got %s:", m1)
 		}
@@ -65,7 +65,7 @@ func TestExpireMessage(t *testing.T) {
 	tc := testcase{newMsg("miek.nl.", dns.TypeMX), false, false}
 	c.InsertMessage(Key(tc.m.Question[0], tc.dnssec, tc.tcp), tc.m)
 
-	m1 := c.Hit(tc.m.Question[0], tc.dnssec, tc.tcp, tc.m.Id)
+	m1, expired, key := c.Hit(tc.m.Question[0], tc.dnssec, tc.tcp, tc.m.Id)
 	if m1.Question[0].Qtype != tc.m.Question[0].Qtype {
 		t.Fatalf("bad Qtype, expected %d, got %d:", tc.m.Question[0].Qtype, m1.Question[0].Qtype)
 	}
@@ -75,7 +75,7 @@ func TestExpireMessage(t *testing.T) {
 
 	time.Sleep(testTTL)
 
-	m1 = c.Hit(tc.m.Question[0], tc.dnssec, tc.tcp, tc.m.Id)
+	m1, expired, key = c.Hit(tc.m.Question[0], tc.dnssec, tc.tcp, tc.m.Id)
 	if m1.Question[0].Qtype != tc.m.Question[0].Qtype {
 		t.Fatalf("bad Qtype, expected %d, got %d:", tc.m.Question[0].Qtype, m1.Question[0].Qtype)
 	}

--- a/main.go
+++ b/main.go
@@ -115,6 +115,11 @@ func main() {
 			EnvVar: "DNSMASQ_RCACHE_TTL",
 		},
 		cli.BoolFlag{
+			Name:   "rcache-preserve-upstream-error",
+			Usage:  "Keep and use cache entries after the TTL expires if the upstream servers are down",
+			EnvVar: "DNSMASQ_RCACHE_PRESERVE_UPSTREAM_ERROR",
+		},
+		cli.BoolFlag{
 			Name:   "no-rec",
 			Usage:  "Disable recursion",
 			EnvVar: "DNSMASQ_NOREC",
@@ -234,22 +239,23 @@ func main() {
 		}
 
 		config := &server.Config{
-			DnsAddr:         listen,
-			DefaultResolver: c.Bool("default-resolver"),
-			Nameservers:     nameservers,
-			Systemd:         c.Bool("systemd"),
-			SearchDomains:   searchDomains,
-			EnableSearch:    enableSearch,
-			Hostsfile:       c.String("hostsfile"),
-			PollInterval:    c.Int("hostsfile-poll"),
-			RoundRobin:      c.Bool("round-robin"),
-			NoRec:           c.Bool("no-rec"),
-			FwdNdots:        c.Int("fwd-ndots"),
-			Ndots:           c.Int("ndots"),
-			ReadTimeout:     2 * time.Second,
-			RCache:          c.Int("rcache"),
-			RCacheTtl:       c.Int("rcache-ttl"),
-			Verbose:         c.Bool("verbose"),
+			DnsAddr:                     listen,
+			DefaultResolver:             c.Bool("default-resolver"),
+			Nameservers:                 nameservers,
+			Systemd:                     c.Bool("systemd"),
+			SearchDomains:               searchDomains,
+			EnableSearch:                enableSearch,
+			Hostsfile:                   c.String("hostsfile"),
+			PollInterval:                c.Int("hostsfile-poll"),
+			RoundRobin:                  c.Bool("round-robin"),
+			NoRec:                       c.Bool("no-rec"),
+			FwdNdots:                    c.Int("fwd-ndots"),
+			Ndots:                       c.Int("ndots"),
+			ReadTimeout:                 2 * time.Second,
+			RCache:                      c.Int("rcache"),
+			RCacheTtl:                   c.Int("rcache-ttl"),
+			RCachePreserveUpstreamError: c.Bool("rcache-preserve-upstream-error"),
+			Verbose:                     c.Bool("verbose"),
 		}
 
 		resolvconf.Clean()

--- a/server/config.go
+++ b/server/config.go
@@ -46,6 +46,8 @@ type Config struct {
 	RCache int `json:"rcache,omitempty"`
 	// RCacheTtl, how long to cache in seconds.
 	RCacheTtl int `json:"rcache_ttl,omitempty"`
+	// RCachePreserveUpstreamError
+	RCachePreserveUpstreamError bool `json:rcache_preserve_upstream_error,omitempty"`
 	// How many dots a name must have before we allow to forward the query as-is. Defaults to 1.
 	FwdNdots int `json:"fwd_ndots,omitempty"`
 	// How many dots a name must have before we do an initial absolute query. Defaults to 1.

--- a/server/forwarding.go
+++ b/server/forwarding.go
@@ -139,12 +139,8 @@ func (s *server) ServeDNSForward(w dns.ResponseWriter, req *dns.Msg) *dns.Msg {
 	}
 
 	// If we got here, we either failed to forward the query or the qname was too
-	// short to forward.
-	log.Debugf("[%d] Error forwarding query. Returning SRVFAIL.", req.Id)
-	m := new(dns.Msg)
-	m.SetRcode(req, dns.RcodeServerFailure)
-	writeMsg(w, m)
-	return m
+	// short to forward. The caller needs to handle returning back an error
+	return nil;
 }
 
 // forwardSearch resolves a query by suffixing with search paths
@@ -173,7 +169,7 @@ func (s *server) forwardSearch(req *dns.Msg, tcp bool) (*dns.Msg, error) {
 
 		switch r.Rcode {
 		case dns.RcodeSuccess:
-			// In case of NO_DATA keep searching, otherwise a wildcard entry 
+			// In case of NO_DATA keep searching, otherwise a wildcard entry
 			// could keep us from finding the answer higher in the search list
 			if len(r.Answer) == 0 && !r.MsgHdr.Truncated {
 				nodata = r.Copy()


### PR DESCRIPTION
This might be controversial, but after suffering through another aws dns outage I really want this capability in dnsmasq. I found your project and it was much easier to grok and work with than the original. Hopefully this type of feature will be interesting to you.

- The new --rcache-preserve-upstream-error command line option
changes the cache behavior so that we only delete expired cache
entries if the upstream is still giving us answers. This provides
a way for systems to continue to work if their primary dns server
goes down. We continue to use the last known result for requests
until the upstream starts to answer queries again. This is off by
default as it's a departure from standard ttl behavior, but can be
a very helpful solution in cloud environments where a system has no
control over the upstream dns server.