### PR TITLE
Use the new canonical name for logrus

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -10,7 +10,7 @@ RUN \
   go get github.com/miekg/dns && \
   go get github.com/rcrowley/go-metrics && \
   go get github.com/rcrowley/go-metrics/stathat && \
-  go get github.com/Sirupsen/logrus && \
+  go get github.com/sirupsen/logrus && \
   go get github.com/stathat/go
 
 ENV USER root

--- a/hostsfile/hostsfile.go
+++ b/hostsfile/hostsfile.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/miekg/dns"
 )
 

--- a/hostsfile/utils.go
+++ b/hostsfile/utils.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type hostlist []*hostname

--- a/main.go
+++ b/main.go
@@ -16,8 +16,8 @@ import (
 	"syscall"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
-	logrus_syslog "github.com/Sirupsen/logrus/hooks/syslog"
+	log "github.com/sirupsen/logrus"
+	logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
 	"github.com/codegangsta/cli"
 	"github.com/miekg/dns"
 

--- a/resolvconf/resolvconf.go
+++ b/resolvconf/resolvconf.go
@@ -14,7 +14,7 @@ import (
 	"regexp"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 const RESOLVCONF_COMMENT_ADD = "# added by go-dnsmasq"

--- a/server/config.go
+++ b/server/config.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/codegangsta/cli"
 	"github.com/miekg/dns"
 )

--- a/server/forwarding.go
+++ b/server/forwarding.go
@@ -7,7 +7,7 @@ package server
 import (
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/miekg/dns"
 )
 

--- a/server/server.go
+++ b/server/server.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/coreos/go-systemd/activation"
 	"github.com/janeczku/go-dnsmasq/cache"
 	"github.com/miekg/dns"


### PR DESCRIPTION
This fixes `go get` behavior on non-case sensitive filesystems.