### PR TITLE
Update to alpine 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.8
 MAINTAINER Jan Broer <janeczku@yahoo.com>
 
 ADD https://github.com/janeczku/go-dnsmasq/releases/download/1.0.7/go-dnsmasq-min_linux-amd64 /go-dnsmasq


### PR DESCRIPTION
Alpine 3.4 has several CVEs:
* CVE-2016-9843
* CVE-2016-9841
* CVE-2016-9840
* CVE-2016-9842